### PR TITLE
Fixes found in second deployment

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -115,7 +115,7 @@ class App():
         # do required init
         if need_set:
             if macclass != "C":
-                self.radio.mac_set_class("C")
+                self.radio.mac_set_class(b"C")
             diff_mask = desired_mask ^ mask
             for iChannel in range(72):
                 iChannel_bit = int(1) << iChannel

--- a/bridge.py
+++ b/bridge.py
@@ -103,6 +103,7 @@ class App():
 
         if (not need_set) and not macstatus.need_join():
             self.log.info("Already joined as class C, assume radio state is corect")
+            self.send_dummy_line()
             return
 
         desired_mask = (int(1) << 65) | (int(0xFF) << 8)
@@ -127,6 +128,14 @@ class App():
             self.log.info("joining...")
             self.radio.mac_join(b"otaa")
             self.log.info("join accepted")
+        self.send_dummy_line()
+
+    def send_dummy_line(self):
+        # send a dummy msg to ensure Class C works
+        # ref: https://www.thethingsindustries.com/docs/devices/configuring-devices/class-c/#enabling-and-disabling-class-c
+        self.log.info("Sending dummy msg to port 42")
+        self.radio.write(42, b"\xff")
+        self.log.info("Dummy msg sent")
 
 def main():
     global gApp

--- a/rn2903.py
+++ b/rn2903.py
@@ -653,7 +653,7 @@ class Rn2903():
 
     def write(self, port, buf):
         """ send the characters in buf to port; unconfirmed """
-        b = [ b'mac', b'tx', b'uncnf', b"%d" % port, binascii.hexlify(buf) ].join(b' ')
-        self.log.debug("queue uplink command: %s", str(b), encoding='ascii')
+        b = b' '.join([ b'mac', b'tx', b'uncnf', b"%d" % port, binascii.hexlify(buf) ])
+        self.log.debug("queue uplink command: %s", str(b, encoding='ascii'))
         self.macll_send_command_indication(b)
 


### PR DESCRIPTION
In using this in a second deployment, it looks as if a couple of key commits never got pushed from the development Pi. So those were recreated and pushed.

In addition, TTN requires a Class-A uplink to enable class C operation. So we added that as part of initialization.

Thanks @mukeshbharath for the help on this.